### PR TITLE
Create separate groups for database Gems

### DIFF
--- a/client/Gemfile
+++ b/client/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.1.6'
 
-gem 'mysql2'
-gem 'pg'
+gem 'mysql2', group: :mysql
+gem 'pg', group: :postgres
 
 gem 'sass-rails', '~> 4.0.0'
 

--- a/cms/Gemfile
+++ b/cms/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.8'
 
-gem 'mysql2'
-gem 'pg'
+gem 'mysql2', group: :mysql
+gem 'pg', group: :postgres
 
 
 # Use SCSS for stylesheets


### PR DESCRIPTION
[GitLab](https://github.com/gitlabhq/gitlabhq/blob/master/Gemfile#L12),
for example, adds the database Gems mysql2 and pg to separate groups, 
allowing to exclude the installation of the unneeded Gems.

With the command below, the user can avoid installing the the unneeded 
Gems and their dependencies, especially as both Gems, mysql2 and pg, 
need installed header files for successful installation.

        bundle install --deployment --without development test mysql aws