### PR TITLE
Fix account confirmation, password reset, and account unlock

### DIFF
--- a/cms/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/cms/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token) %></p>
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @resource.confirmation_token) %></p>

--- a/cms/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/cms/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @resource.confirmation_token) %></p>
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/cms/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/cms/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @resource.reset_password_token) %></p>
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @resource.reset_password_token) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/cms/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/cms/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @resource.reset_password_token) %></p>
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/cms/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/cms/app/views/devise/mailer/unlock_instructions.html.erb
@@ -4,4 +4,4 @@
 
 <p>Click the link below to unlock your account:</p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @resource.unlock_token) %></p>
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @resource.unlock_token) %></p>

--- a/cms/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/cms/app/views/devise/mailer/unlock_instructions.html.erb
@@ -4,4 +4,4 @@
 
 <p>Click the link below to unlock your account:</p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @resource.unlock_token) %></p>
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>


### PR DESCRIPTION
Currently, account confirmation, password reset, and account unlock do not
work due to outdated Devise mailer views.

From [How To: Upgrade to Devise 3.1](https://github.com/plataformatec/devise/wiki/How-To:-Upgrade-to-Devise-3.1):

> The Devise mailer and its views were changed to explicitly receive a token 
> argument as @token. You will need to update your mailers and re-copy the
> views to your application with rails g devise:views