### PR TITLE
Add sample secrets config file

### DIFF
--- a/client/config/secrets.yml.sample
+++ b/client/config/secrets.yml.sample
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: <%= app_secret %>
+
+test:
+  secret_key_base: <%= app_secret %>
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%%= ENV["SECRET_KEY_BASE"] %>

--- a/cms/config/secrets.yml.sample
+++ b/cms/config/secrets.yml.sample
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: <%= app_secret %>
+
+test:
+  secret_key_base: <%= app_secret %>
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
Add `config/secrets.yml.sample` which the user can just copy to `config/secrets.yml`,
already listed in `.gitignore` so it’s ignored by git.