### PR TITLE
config/initializers: Only overwrite `puts` in development environment

### DIFF
--- a/client/config/initializers/patch_application.rb
+++ b/client/config/initializers/patch_application.rb
@@ -1,13 +1,15 @@
 # -*- encoding : utf-8 -*-
 
-def puts(input, hirb=true)
-  if hirb
-    if input.is_a?(String)
-      super("==> #{input}")
+if Rails.env.development?
+  def puts(input, hirb=true)
+    if hirb
+      if input.is_a?(String)
+        super("==> #{input}")
+      else
+        super( Hirb::Helpers::AutoTable.render(input) )
+      end
     else
-      super( Hirb::Helpers::AutoTable.render(input) )
+      super(input)
     end
-  else
-    super(input)
   end
 end

--- a/cms/config/initializers/patch_application.rb
+++ b/cms/config/initializers/patch_application.rb
@@ -1,13 +1,15 @@
 # -*- encoding : utf-8 -*-
 
-def puts(input, hirb=true)
-  if hirb
-    if input.is_a?(String)
-      super("==> #{input}")
+if Rails.env.development?
+  def puts(input, hirb=true)
+    if hirb
+      if input.is_a?(String)
+        super("==> #{input}")
+      else
+        super( Hirb::Helpers::AutoTable.render(input) )
+      end
     else
-      super( Hirb::Helpers::AutoTable.render(input) )
+      super(input)
     end
-  else
-    super(input)
   end
 end


### PR DESCRIPTION
Overwriting the method `puts` breaks Phusion Passenger.

Copied from go~mus [1]. The code is not removed but only loaded when running in
the development environment.

---------- 8< ---------------- >8 ----------
The removed code, overwriting the method `puts` seems to redirect the standard
output. This works fine with Phusion Passenger 3.0.12 but breaks at least
Phusion Passenger 5.0.14. Newer Phusion Passenger rely on the standard output
to communicate with the application [1].

> Phusion Passenger uses the application's stdout for communication with
> the application. This means that if, during any of those steps, stdout
> is closed, overwritten or redirected to a file, then Phusion Passenger
> loses its means to communicate with the application. After a while,
> Phusion Passenger concludes that the application fails to start up,
> and reports an error.

The reported error looks something like.

```
[ 2015-07-23 13:44:43.8402 248/7f637efba700 age/Cor/Req/CheckoutSession.cpp:252 ]: [Client 1-1] Cannot checkout session because a spawning error occurred. The identifier of the error is 4a75984e. Please see earlier logs for details about the error.
App 314 stdout:
App 314 stderr: fatal: Not a git repository (or any of the parent directories): .git
App 314 stderr: fatal: Not a git repository (or any of the parent directories): .git
App 314 stderr: fatal: Not a git repository (or any of the parent directories): .git
App 314 stdout: ==> !> Ready
App 314 stdout: ==> !> socket: unix:/tmp/passenger.yjOzOER/apps.s/preloader.1exg9a0
App 314 stdout: ==> !>
[ 2015-07-23 13:47:22.3645 248/7f637c32c700 App/Implementation.cpp:303 ]: Could not spawn process for application /home/app: An error occurred while starting up the preloader: it did not write a startup response in time.
  Error ID: 83f49821
  Error details saved to: /tmp/passenger-error-ZJARdM.html
  Message from application: An error occurred while starting up the preloader: it did not write a startup response in time. Please read <a href="https://github.com/phusion/passenger/wiki/Debugging-application-startup-problems">this article</a> for more information about this problem.<br>
<h2>Raw process output:</h2>
<pre>
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
==> !> Ready
==> !> socket: unix:/tmp/passenger.yjOzOER/apps.s/preloader.1exg9a0
==> !>
</pre>
```

Took me 1.5 days to figure that out. While it looks obvious afterward,
it wasn’t for me. Due to inexperience and do to `git grep -i stdout` not
giving any results.

[1] https://github.com/phusion/passenger/wiki/Debugging-application-startup-problems#stdout-redirection
---------- 8< ---------------- >8 ----------

[2] https://gitlab6.giantmonkey.de/go-mus/md-dispo/merge_requests/334#note_2216