### PR TITLE
Fix spelling in option description

### DIFF
--- a/cms/app/views/content_element_types/_meta_hints.html.haml
+++ b/cms/app/views/content_element_types/_meta_hints.html.haml
@@ -10,7 +10,7 @@
       %strong
         Auswahl : Ziel-Inhaltstyp (matches intern)
       %br
-      Erstellt eine Auswahl-Liste mit Inhalten deren intern Feld dem intern-feld dieses Feldes entspricht.
+      Erstellt eine Auswahlliste mit Inhalten deren intern Feld dem intern-feld dieses Feldes entspricht.
 
 
 

--- a/cms/app/views/content_element_types/_meta_hints.html.haml
+++ b/cms/app/views/content_element_types/_meta_hints.html.haml
@@ -10,7 +10,7 @@
       %strong
         Auswahl : Ziel-Inhaltstyp (matches intern)
       %br
-      Erstellt eine Auswahlliste mit Inhalten deren intern Feld dem intern-feld dieses Feldes entspricht.
+      Erstellt eine Auswahlliste mit Inhalten, deren intern Feld dem intern-feld dieses Feldes entspricht.
 
 
 

--- a/cms/app/views/content_element_types/_meta_hints.html.haml
+++ b/cms/app/views/content_element_types/_meta_hints.html.haml
@@ -10,7 +10,7 @@
       %strong
         Auswahl : Ziel-Inhaltstyp (matches intern)
       %br
-      Erstellt eine Auswahlliste mit Inhalten, deren intern Feld dem intern-feld dieses Feldes entspricht.
+      Erstellt eine Auswahlliste mit Inhalten, deren Intern-Feld dem Intern-Feld dieses Feldes entspricht.
 
 
 

--- a/cms/app/views/content_element_types/_meta_hints.html.haml
+++ b/cms/app/views/content_element_types/_meta_hints.html.haml
@@ -10,7 +10,7 @@
       %strong
         Auswahl : Ziel-Inhaltstyp (matches intern)
       %br
-      Erstellt eine Auswhal-Liste mit Inhalten deren intern Feld dem intern-feld dieses Feldes entspricht.
+      Erstellt eine Auswahl-Liste mit Inhalten deren intern Feld dem intern-feld dieses Feldes entspricht.
 
 
 


### PR DESCRIPTION
Go to https://www.example.net/projects/3/content_types/12/content_element_types/105/edit
for example.