### PR TITLE
client: Upgrade Gem newrelic_rpm to 3.15.0.314

### DIFF
--- a/client/Gemfile.lock
+++ b/client/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     minitest (5.8.4)
     multi_json (1.11.2)
     mysql2 (0.3.16)
-    newrelic_rpm (3.14.2.312)
+    newrelic_rpm (3.15.0.314)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
     paperclip (4.2.0)


### PR DESCRIPTION
Run `bundle update newrelic_rpm` to upgrade the New Relic Ruby Agent
from 3.14.2.312 to 3.15.0.314.

Change log [1]:

```
v3.15.0
-------

  * Rails 5 support

  This release includes experimental support for Rails 5 as of 5.0.0.beta2.
  Please note that this release does not include any support for ActionCable,
  the WebSockets framework new to Rails 5.

  * Don't include extension from single format Grape API transaction names

  Starting with Grape 0.12.0, an API with a single format no longer declares
  methods with `.:format`, but with an extension such as `.json`. Thanks Daniel
  Doubrovkine for the contribution!

  * Fix warnings about shadowing outer local variable when running tests

  Thanks Rafael Almeida de Carvalho for the contribution!

  * Check config first for Rails middleware instrumentation installation

  Checking the config first avoids issues with mock classes that don't implement
  `VERSION`. Thanks Jesse Sanford for the contribution!

  * Remove a trailing whitespace in the template for generated newrelic.yml

  Thanks Paul Menzel for the contribution!

  * Reference external resources in comments and readme with HTTPS

  Thanks Benjamin Quorning for the contribution!

v3.14.3
-------

  * Don't inadvertently send sensitive information from DataMapper SQLErrors

  DataObjects::SQLError captures the SQL query, and when using versions of
  data_objects prior to 0.10.8, built a URI attribute that contained the
  database connection password. The :query attribute now respects the obfuscation
  level set for slow SQL traces and splices out any password parameters to the
  URI when sending up traced errors to New Relic.

  * Improved SQL obfuscation algorithm

  To help standardize SQL obfuscation across New Relic language agents, we've
  improved the algorithm used and added more test cases.

  * Configurable longer sql_id attribute on slow SQL traces

  The sql_id attribute on slow SQL traces is used to aggregate normalized
  queries together. Previously, these IDs would generally be 9-10 digits long,
  due to a backend restriction. If `slow_sql.use_longer_sql_id` is set to `true`,
  these IDs will now be 18-19 digits long.
```

[1] https://github.com/newrelic/rpm/blob/master/CHANGELOG