### PR TITLE
client: Upgrade Gem Mysql2 from 0.3.16 to 0.4.3

### DIFF
--- a/client/Gemfile.lock
+++ b/client/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     mini_portile (0.6.0)
     minitest (5.8.4)
     multi_json (1.11.2)
-    mysql2 (0.3.16)
+    mysql2 (0.4.3)
     newrelic_rpm (3.15.0.314)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)


### PR DESCRIPTION
Run `bundle update mysql2` to upgrade the Gem Mysql2 [1] from 0.3.16
[2], released in May 2014, to 0.4.3 [3], released in February 2016.

The change log [4] is too long to list it here, so just list the notes
for the release 0.4.3.

> # New Features
>
> * Add method Client#ssl_cipher to expose mysql_get_ssl_cipher
> * Add method Result#free to immediately free a result set
> * Add connection flag automatic_close: true/false to determine whether
>   to work around connections being closed by garbage collection in a
>   child after a fork. Default is true, which restores behavior prior
>   to 0.3.16.
>
> # Bugfixes
>
> * Fix to hold the GVL between mysql_stmt_execute and
> mysql_stmt_store_result to prevent commands hitting the wire out of
> sync (e.g. if a GC run occurs in the middle)
> * Fix BigDecimal arguments to Prepared Statements were ignored
> * Fix rake re-definition warning
>
> # Changes
>
> * Add Ruby 2.3 to the Travis CI matrix
> * Allow nil for timeouts instead of casting to 0 when creating a
>   Client instance
> * Add connection flag automatic_close: true/false to determine whether
>   to work around connections being closed by garbage collection in a
>   child after a fork. Default is true, which restores behavior prior
>   to 0.3.16.

[1] https://github.com/brianmario/mysql2
    Mysql2 - A modern, simple and very fast MySQL library for Ruby - binding to libmysql
[2] https://github.com/brianmario/mysql2/releases/tag/0.3.16
[3] https://github.com/brianmario/mysql2/releases/tag/0.4.3
[4] https://github.com/brianmario/mysql2/releases