### PR TITLE
Use Rails cache for storing session data

### DIFF
--- a/cms/config/initializers/session_store.rb
+++ b/cms/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Delta2::Application.config.session_store :mem_cache_store, key: 'delta2'
+Delta2::Application.config.session_store :cache_store, key: 'delta2'


### PR DESCRIPTION
Set the session store to `ActionDispatch::Session::CacheStore` in the session
store initializer, to store the data in the Rails cache.