### PR TITLE
add hidden attribute to permitted_params for content

### DIFF
--- a/cms/app/models/permitted_params.rb
+++ b/cms/app/models/permitted_params.rb
@@ -68,7 +68,7 @@ class PermittedParams < Struct.new(:params, :current_user)
   end
 
   def content_attributes
-    [:old_id, :ref_id, :project_id, :content_type_id, :alpha_datum, :omega_datum, :branch_ids => [], :workspace_ids => [], :content_element_attributes => [:content_id, :content_element_type_id, :language, :value, :status] ]
+    [:old_id, :ref_id, :project_id, :content_type_id, :alpha_datum, :omega_datum, :hidden, :branch_ids => [], :workspace_ids => [], :content_element_attributes => [:content_id, :content_element_type_id, :language, :value, :status] ]
   end
 
 


### PR DESCRIPTION
The attribute `hidden` was not saved. Add it to the content attributes in the permitted
parameters model.

Fixes: [OP #4450](https://projects.giantmonkey.de/work_packages/4450)