### PR TITLE
Fix content creation

### DIFF
--- a/cms/app/helpers/contents_helper.rb
+++ b/cms/app/helpers/contents_helper.rb
@@ -11,7 +11,7 @@ module ContentsHelper
     identifier = "content_elements[add][#{content_element_type.id}]"
 
     ce = content.value(content_element_type.id, @locale)
-    if ce
+    if ce.try(:id)
       identifier = "content_elements[update][#{ce.try(:id)}]"
       value = ce.try(:value) || ''
         value.strip!

--- a/cms/app/views/contents/index.html.haml
+++ b/cms/app/views/contents/index.html.haml
@@ -112,7 +112,7 @@
         - if current_user.admin? || Permission.is_stored?(current_user, @project, :create, @content_type.class.name, @content_type.id)
           .clearfix
           %hr
-          = link_to new_project_content_type_content_path(@project, @content_type, params.merge(:branch => @branch)), :class => 'btn btn-mini btn-primary pull-right' do
+          = link_to new_project_content_type_content_path(@project, @content_type, branch: @branch), :class => 'btn btn-mini btn-primary pull-right' do
             %i.fa.fa-plus
             &nbsp;
             %strong


### PR DESCRIPTION
An error created `update` fields instead of `create` fields so the content was lost by creating new contents.