### PR TITLE
Fix media library popover

### DIFF
--- a/cms/app/controllers/documents_controller.rb
+++ b/cms/app/controllers/documents_controller.rb
@@ -68,6 +68,8 @@ class DocumentsController < ApplicationController
   def search
     @documents = @project.documents.finder(params[:search]).doctype(params[:doctype])
 
+    @parent = params[:parent_type].singularize.classify.constantize.find_by_id(params[:parent_id]) if params[:parent_type] && params[:parent_id]
+
     if @parent
       @documents = @documents - @parent.documents
       @documents = Kaminari.paginate_array(@documents).page(params[:page]).per(10)

--- a/cms/app/views/documents/_popover.html.haml
+++ b/cms/app/views/documents/_popover.html.haml
@@ -14,12 +14,13 @@
 
 .clearfix
 
-%table.table.table-condensed.table-bordered.table-striped
+%table.table.table-condensed.table-hover
   - @documents.each do |document|
     %tr.fxline{ :id => "document#{document.id}" }
       %td{ :width => 50 }
         = image_tag document.document.url(:thumb)
-
+      %td
+        = "[img:#{document.id}]"
       %td
         %strong
           = document.filetype
@@ -28,12 +29,13 @@
         %br
         = number_to_human_size document.document_file_size
       %td
-        - if @parent && @parent.class.name == 'Content'
-          = link_to assign_project_content_document_path(@project, @parent, document), :remote => true, :class => 'btn btn-mini' do
-            Übernehmen
-        - elsif @parent && @parent.class.name == 'Branch'
-          = link_to assign_project_branch_document_path(@project, @parent, document), :remote => true, :class => 'btn btn-mini' do
-            Übernehmen
+        .pull-right
+          - if @parent && @parent.class.name == 'Content'
+            = link_to assign_project_content_document_path(@project, @parent, document), :remote => true, :class => 'btn btn-mini' do
+              Übernehmen
+          - elsif @parent && @parent.class.name == 'Branch'
+            = link_to assign_project_branch_document_path(@project, @parent, document), :remote => true, :class => 'btn btn-mini' do
+              Übernehmen
 
 
 = paginate @documents , :remote => true

--- a/cms/app/views/documents/index.js.erb
+++ b/cms/app/views/documents/index.js.erb
@@ -1,7 +1,12 @@
-$("#mmw").remove();
+if($('#mbm').length > 0) {
+  $('#mbm .modal-body').html('<%= j( render :partial => 'documents/popover' ) %>');
+}
+else {
+  $("body").append('<div id="mbm" class="modal hide fade"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button><h3>Medienbibliothek</h3></div><div class="modal-body" style="max-height: 720px;"><%= j( render :partial => 'documents/popover' ) %></div></div>');
+}
 
-$("body").append('<div id="mmw" title="Medienbibliothek"><%= j( render :partial => 'documents/popover' ) %></div>');
-
-$("#mmw").dialog( { width: 600 });
+if( !$('#mbm').hasClass('in') ) {
+  $("#mbm").modal( );
+}
 
 NProgress.done();


### PR DESCRIPTION
The current media library popover is built by using jQuery UI, this pull request changes it to Bootstrap modal. It also fixes an issue by „detecting“ the parent of its polymorphic documentables, so the assign buttons can be displayed. it also brings back the search field :)

![old](https://cloud.githubusercontent.com/assets/992529/13878563/92a184a6-ed12-11e5-87cb-f5426d2488b9.png)

![new](https://cloud.githubusercontent.com/assets/992529/13878572/a13bd8fe-ed12-11e5-8735-c4421768936b.png)
