### PR TITLE
Execute create uploader inline

### DIFF
--- a/cms/app/views/documents/_button.html.erb
+++ b/cms/app/views/documents/_button.html.erb
@@ -67,10 +67,7 @@
         });
       }
 
-      $(document).on('ready page:load', function() {
 
-        createUploader();
-
-      });
+      createUploader();
     <% end %>
 <% end %>

--- a/cms/app/views/documents/_button.html.erb
+++ b/cms/app/views/documents/_button.html.erb
@@ -1,6 +1,5 @@
 <% if can?(:create, :documents) %>
   <div id="bootstrapped-fine-uploader"></div>
-  <% content_for :scripts do %>
     <%= javascript_tag do %>
       var fileCount = 0;
       var addedFiles = 0;
@@ -74,5 +73,4 @@
 
       });
     <% end %>
-  <% end %>
 <% end %>


### PR DESCRIPTION
This might be a regression, because using `content_for :scripts` and using the `page:load` event was used to fit turbolinks – but I've to renovate the upload process by switching from Fine Uploader 3.8 to the current 5.5 (which needs more adaptations), so the advantage of this fix outweigh the disadvantages of waiting for the uploader update..