### PR TITLE
Update Gem EventMachine to 1.2.0.1

### DIFF
--- a/client/Gemfile.lock
+++ b/client/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     dalli (2.7.4)
     debug_inspector (0.0.2)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.2.0.1)
     exception_notification (4.0.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)


### PR DESCRIPTION
The new version fixes build errors with newer tools.